### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "antd-mobile": "^2.2.13",
     "axios": "^0.19.0",
     "eslint-plugin-react-hooks": "^1.6.0",
-    "npm": "^6.9.0",
     "rc-form": "^2.4.5",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",


### PR DESCRIPTION

Hello wosxieez!

It seems like you have npm as one of your (dev-) dependency in factory-mobile.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
